### PR TITLE
Automatically run code coverage in travis

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@
 ^NEWS\.md$
 ^README\.Rmd$
 ^\.travis\.yml$
+^codecov\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@
 
 language: R
 cache: packages
+
+after_success:
+  - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Suggests:
     charlatan,
     roxygen2,
     rmarkdown,
-    testthat
+    testthat,
+    covr
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,6 +17,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![Travis build status](https://travis-ci.org/UW-GAC/contactparser.svg?branch=master)](https://travis-ci.org/UW-GAC/contactparser)
+[![Codecov test coverage](https://codecov.io/gh/UW-GAC/contactparser/branch/master/graph/badge.svg)](https://codecov.io/gh/UW-GAC/contactparser?branch=master)
 <!-- badges: end -->
 
 The contactparser package was designed to parse and reformat the [Contacts table](https://www.nhlbiwgs.org/contact-filter) on the TOPMed website.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 [![Travis build
 status](https://travis-ci.org/UW-GAC/contactparser.svg?branch=master)](https://travis-ci.org/UW-GAC/contactparser)
+[![Codecov test
+coverage](https://codecov.io/gh/UW-GAC/contactparser/branch/master/graph/badge.svg)](https://codecov.io/gh/UW-GAC/contactparser?branch=master)
 <!-- badges: end -->
 
 The contactparser package was designed to parse and reformat the

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
Add required files to check test coverage in travis using covr, and
update the travis yaml file to automatically run this check. Add a
badge to the README file and re-render it.

Note: these updates were made automatically by running usethis::use_coverage().